### PR TITLE
Fix valid requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-requests
+requests==2.20.0


### PR DESCRIPTION
```
Found valid requirements file(s):
requirements.txt
All packages are up-to-date.

Upgrade interrupted.
```

```
Reading requirements.txt...
Error: Can only work with pinned requirements for now.
Traceback (most recent call last):
  File "/usr/local/bin/upgrade-requirements", line 11, in <module>
    load_entry_point('upgrade-requirements==1.7.0', 'console_scripts', 'upgrade-requirements')()
  File "/usr/local/lib/python3.6/site-packages/upgrade_requirements.py", line 58, in main
    name, version = requirement.split('==')
ValueError: not enough values to unpack (expected 2, got 1)
```