### PR TITLE
Feature multiple sender

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -46,4 +46,3 @@ jobs:
           python -m pip install --upgrade pip
           pip install -r requirements.txt
           echo '${{ secrets.COOKIE }}' | tr '#' '\n' | sed 's/$/&#${{ secrets.SCKEY }}/g' | xargs -I {} sh -c 'echo "{}" | python3 ./genshin.py'
-

--- a/README.md
+++ b/README.md
@@ -146,6 +146,35 @@ Error: Process completed with exit code 255.
 
 </details>
 
+## 🔔订阅
+
+#### 若开启订阅推送，无论成功与否，都会收到微信通知。
+
+- 使用 GitHub 登录 [sc.ftqq.com](http://sc.ftqq.com/?c=github&a=login) 创建账号
+- 点击「[发送消息](http://sc.ftqq.com/?c=code)」，获取`SCKEY`
+- 点击「[微信推送](http://sc.ftqq.com/?c=wechat&a=bind)」，完成微信绑定
+- 建立名为`SCKEY`的 secret，并添加获取的 SCKEY 值，即可开启订阅推送
+
+#### 如果需要额外的通知渠道可以自己根据一下规则实现
+- 认证信息使用 `secret` 存储 (推荐)
+- 所有通知渠道放到`notify.py`内实现, 继承自`Sender` 类
+
+通知调用格式, `message` 为原始信息包含以下`key`
+```python
+# today             当天时间
+# region_name       区服
+# uid               UID
+# award_name        礼品
+# award_cnt         礼品数量
+# total_sign_day    签到天数
+# status            上层API返回的 messgae 字段或自定义的消息
+# end               格式化用
+
+# 在 notify.py 中按照以下签名实现自己的通知渠道即可
+def send(self, title, status, message):
+     """please implemente in subclass"""
+```
+
 ## 🔨开发
 
 如果需要重构或增加额外功能参考以下数据
@@ -189,15 +218,6 @@ infos = [
 ]
 
 ```
-## 🔔订阅
-
-若开启订阅推送，无论成功与否，都会收到微信通知。
-
-- 使用 GitHub 登录 [sc.ftqq.com](http://sc.ftqq.com/?c=github&a=login) 创建账号
-- 点击「[发送消息](http://sc.ftqq.com/?c=code)」，获取`SCKEY`
-- 点击「[微信推送](http://sc.ftqq.com/?c=wechat&a=bind)」，完成微信绑定
-- 建立名为`SCKEY`的 secret，并添加获取的 SCKEY 值，即可开启订阅推送
-
 ## ❗️协议
 
 使用 Genshin Impact Helper 即表明，您知情并同意：

--- a/genshin.py
+++ b/genshin.py
@@ -198,8 +198,8 @@ class Sign(Base):
                         today,
                         self._region_name_list[i],
                         uid,
-                        award['name'],
-                        award['cnt'],
+                        award[total_sign_day]['name'],
+                        award[total_sign_day]['cnt'],
                         total_sign_day + 1,
                         response['message'],
                         ''

--- a/genshin.py
+++ b/genshin.py
@@ -8,7 +8,10 @@ import uuid
 import requests
 from requests.exceptions import *
 
+from notify import *
 from settings import *
+
+notify = Notify(notify_class=CONFIG.NOTIFY_CLASS)
 
 
 def hexdigest(text):
@@ -44,7 +47,7 @@ class Base(object):
 
 class Roles(Base):
     def get_awards(self):
-        response = dict
+        response = dict()
         try:
             content = requests.Session().get(CONFIG.AWARD_URL, headers=self.get_header()).text
             response = self.to_python(content)
@@ -96,7 +99,8 @@ class Sign(Base):
 
     @staticmethod
     def get_ds():
-        n = 'h8w582wxwgqvahcdkpvdhbh2w9casgfl'  # v2.3.0 web @povsister & @journey-ad
+        # v2.3.0-web @povsister & @journey-ad
+        n = 'h8w582wxwgqvahcdkpvdhbh2w9casgfl'
         i = str(int(time.time()))
         r = ''.join(random.sample(string.ascii_lowercase + string.digits, 6))
         c = hexdigest('salt=' + n + '&t=' + i + '&r=' + r)
@@ -122,7 +126,7 @@ class Sign(Base):
 
         # role list empty
         if not role_list:
-            notify(sc_secret, '失败', user_game_roles.get('message', 'role list empty'))
+            notify.send(title="", status='失败', message=user_game_roles.get('message', 'role list empty'))
             exit(-1)
 
         log.info('当前账号绑定了 {} 个角色'.format(len(role_list)))
@@ -156,26 +160,25 @@ class Sign(Base):
         for i in range(len(info_list)):
             today = info_list[i]['data']['today']
             total_sign_day = info_list[i]['data']['total_sign_day']
-            award = Roles(self._cookie).get_awards()['data']['awards']
+            awards = Roles(self._cookie).get_awards()['data']['awards']
             uid = str(self._uid_list[i]).replace(str(self._uid_list[i])[3:6], '***', 1)
 
             messgae = {
                 'today': today,
                 'region_name': self._region_name_list[i],
                 'uid': uid,
-                'award_name': award[total_sign_day]['name'],
-                'award_cnt': award[total_sign_day]['cnt'],
+                'award_name': awards[total_sign_day - 1]['name'],
+                'award_cnt': awards[total_sign_day - 1]['cnt'],
+                'total_sign_day': total_sign_day,
                 'end': '',
             }
             if info_list[i]['data']['is_sign'] is True:
-                messgae['total_sign_day'] = total_sign_day + 1
                 messgae['status'] = "👀 旅行者 {} 号, 你已经签到过了哦".format(i + 1)
-                notify(sc_secret, "成功", self.message.format(**messgae))
+                notify.send(title="", status='成功', message=messgae)
                 continue
             if info_list[i]['data']['first_bind'] is True:
-                messgae['total_sign_day'] = total_sign_day
                 messgae['status'] = "💪 旅行者 {} 号, 请先前往米游社App手动签到一次".format(i + 1)
-                notify(sc_secret, "失败", self.message.format(**messgae))
+                notify.send(title="", status='失败', message=messgae)
                 continue
 
             data = {
@@ -185,7 +188,7 @@ class Sign(Base):
             }
 
             log.info('准备为旅行者 {} 号签到... {}'.format(i + 1, self.to_json({
-                'Region': self._region_name_list[i],
+                '区服': self._region_name_list[i],
                 'UID': uid
             })))
             try:
@@ -200,40 +203,11 @@ class Sign(Base):
             # 0:      success
             # -5003:  already signed in
             if code != 0:
-                notify(sc_secret, "失败", response)
+                notify.send(title="", status="失败", message=response)
                 continue
             messgae['total_sign_day'] = total_sign_day + 1
             messgae['status'] = response['message']
-            notify(sc_secret, "成功", self.message.format(**messgae))
-
-    @property
-    def message(self):
-        return CONFIG.MESSGAE_TEMPLATE
-
-
-def notify(secret: str, status: str, message):
-    if isinstance(message, list) or isinstance(message, dict):
-        message = Sign.to_json(message)
-    log.info('签到{}: {}'.format(status, message))
-
-    if secret.startswith('SC'):
-        log.info('准备推送通知...')
-        url = 'https://sc.ftqq.com/{}.send'.format(secret)
-        data = {'text': '原神签到小助手 签到{}'.format(status), 'desp': message}
-        try:
-            response = Sign.to_python(requests.Session().post(url, data=data).text)
-        except Exception as e:
-            log.error(e)
-            raise HTTPError
-        else:
-            errmsg = response['errmsg']
-            if errmsg == 'success':
-                log.info('推送成功')
-            else:
-                log.error('{}: {}'.format('推送失败', response))
-    else:
-        log.info('未配置SCKEY,正在跳过推送')
-    return log.info('任务结束')
+            notify.send(title="", status="成功", message=messgae)
 
 
 if __name__ == '__main__':

--- a/notify.py
+++ b/notify.py
@@ -1,0 +1,68 @@
+import abc
+import json
+import os
+import sys
+
+import requests
+from requests.exceptions import *
+
+from settings import *
+
+__all__ = ['Notify']
+
+
+class Sender(abc.ABC):
+    @staticmethod
+    def to_python(json_str: str):
+        return json.loads(json_str)
+
+    @staticmethod
+    def to_json(obj):
+        return json.dumps(obj, indent=4, ensure_ascii=False)
+
+    @abc.abstractmethod
+    def send(self, title, status, message):
+        """please implemente in subclass"""
+
+
+class ServerJiang(Sender):
+    def send(self, title, status, message):
+        message = CONFIG.MESSGAE_TEMPLATE.format(**message)
+
+        secret = os.environ.get('SCKEY', '')
+        if isinstance(message, list) or isinstance(message, dict):
+            message = self.to_json(message)
+        log.info('签到{}: {}'.format(status, message))
+
+        if secret.startswith('SC'):
+            log.info('准备推送通知...')
+            url = 'https://sc.ftqq.com/{}.send'.format(secret)
+            data = {'text': '原神签到小助手 签到{}'.format(status), 'desp': message}
+            try:
+                response = self.to_python(requests.Session().post(url, data=data).text)
+            except Exception as e:
+                log.error(e)
+                raise HTTPError
+            else:
+                errmsg = response['errmsg']
+                if errmsg == 'success':
+                    log.info('推送成功')
+                else:
+                    log.error('{}: {}'.format('推送失败', response))
+        else:
+            log.info('未配置SCKEY,正在跳过推送')
+        return log.info('任务结束')
+
+
+class Notify(object):
+    default_notify_class = "ServerJiang"
+
+    def __new__(cls, *args, **kwargs):
+        notify_class = kwargs.get('notify_class', cls.default_notify_class)
+
+        this_mod = sys.modules[__name__]
+        notify_class = getattr(this_mod, notify_class, None)
+
+        if notify_class is None:
+            raise ModuleNotFoundError("not found {}.{}".format(this_mod, notify_class))
+        return notify_class()

--- a/settings.py
+++ b/settings.py
@@ -44,3 +44,14 @@ else:
 
 log.basicConfig(level=CONFIG.LOG_LEVEL)
 
+
+MESSGAE_TEMPLATE = '''
+    {today:#^30}
+    🔅[{region_name}]{uid}
+    今日奖励: {award_name} × {award_cnt}
+    本月累签: {total_sign_day} 天
+    签到结果: {status}
+    {end:#^30}
+'''
+
+CONFIG.MESSGAE_TEMPLATE = MESSGAE_TEMPLATE

--- a/settings.py
+++ b/settings.py
@@ -26,6 +26,7 @@ class _Config:
     SIGN_URL = 'https://api-takumi.mihoyo.com/event/bbs_sign_reward/sign'
     USER_AGENT = 'Mozilla/5.0 (iPhone; CPU iPhone OS 14_0_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) ' \
                  'miHoYoBBS/{}'.format(APP_VERSION)
+    NOTIFY_CLASS = os.environ.get('NotifyClass', 'ServerJiang')
 
 
 class ProductionConfig(_Config):
@@ -51,7 +52,6 @@ MESSGAE_TEMPLATE = '''
     今日奖励: {award_name} × {award_cnt}
     本月累签: {total_sign_day} 天
     签到结果: {status}
-    {end:#^30}
-'''
+    {end:#^30}'''
 
 CONFIG.MESSGAE_TEMPLATE = MESSGAE_TEMPLATE


### PR DESCRIPTION
#### 如果需要额外的通知渠道可以自己根据一下规则实现
- 认证信息使用 `secret` 存储 (推荐)
- 所有通知渠道放到`notify.py`内实现, 继承自`Sender` 类

通知调用格式, `message` 为原始信息包含以下`key`
```python
# today             当天时间
# region_name       区服
# uid               UID
# award_name        礼品
# award_cnt         礼品数量
# total_sign_day    签到天数
# status            上层API返回的 messgae 字段或自定义的消息
# end               格式化用

# 在 notify.py 中按照以下签名实现自己的通知渠道即可
def send(self, title, status, message):
     """please implemente in subclass"""
```