### PR TITLE
允许自定义Telegram API地址

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Genshin Impact Helper 可以自动化为你获取原神每日福利。
 1. Fork 仓库
 2. 获取 Cookie
 3. 添加 Cookie 至 Secrets
-4. 启用 Actions
+4. 启用 Action
 
 <details>
 <summary>查看教程</summary>
@@ -267,6 +267,7 @@ if (ask == true) {
 |   COOL_PUSH_MODE  | ❌         | send               |   Cool Push的推送方式.可选私聊(send)、群组(group)或者微信(wx).      |
 |   BARK_KEY        | ❌         |                    |   Bark的IP或设备码                                                |
 |   BARK_SOUND      | ❌         | healthnotification |   Bark的推送铃声.在APP内查看铃声列表                                |
+|   TG_BOT_API      | ❌         | api.telegram.org   |   Telegram 的API地址 (可以自定义为反向代理服务器)                       |
 |   TG_BOT_TOKEN    | ❌         |                    |   Telegram Bot的token.向bot father申请bot时生成                    |
 |   TG_USER_ID      | ❌         |                    |   Telegram推送对象的用户ID                                         |
 |   DD_BOT_TOKEN    | ❌         |                    |   钉钉机器人WebHook地址中access_token后的字段                       |

--- a/notify.py
+++ b/notify.py
@@ -21,6 +21,7 @@ class Notify(object):
     :param COOL_PUSH_MODE: Cool Push的推送方式.可选私聊(send)、群组(group)或者微信(wx),默认: send
     :param BARK_KEY: Bark的IP或设备码.例如: https://api.day.app/xxxxxx
     :param BARK_SOUND: Bark的推送铃声.在APP内查看铃声列表,默认: healthnotification
+    :param TG_BOT_API: Telegram Bot的api地址, 用于反向使用代理Telegram API地址.
     :param TG_BOT_TOKEN: Telegram Bot的token.向bot father申请bot时生成.
     :param TG_USER_ID: Telegram推送对象的用户ID.
     :param DD_BOT_TOKEN: 钉钉机器人WebHook地址中access_token后的字段.
@@ -66,6 +67,7 @@ class Notify(object):
     BARK_KEY = ''
     BARK_SOUND = 'healthnotification'
     # Telegram Bot
+    TG_BOT_API = 'api.telegram.org'
     TG_BOT_TOKEN = ''
     TG_USER_ID = ''
     # DingTalk Bot
@@ -187,7 +189,10 @@ class Notify(object):
         if TG_BOT_TOKEN and TG_USER_ID:
             token = 'token'
 
-        url = f'https://api.telegram.org/bot{TG_BOT_TOKEN}/sendMessage'
+        if 'TG_BOT_API' in os.environ:
+            TG_BOT_API = os.environ['TG_BOT_API']
+
+        url = f'https://{TG_BOT_API}/bot{TG_BOT_TOKEN}/sendMessage'
         data = {
             'chat_id': TG_USER_ID,
             'text': f'{text} {status}\n\n{desp}',


### PR DESCRIPTION
用于DOCKER部署的情况下使用反向代理避免网络无法访问官方API